### PR TITLE
⬆️ Migrate to OpenTK.Audio.OpenAL 4.8

### DIFF
--- a/src/Bearded.Audio/Bearded.Audio.csproj
+++ b/src/Bearded.Audio/Bearded.Audio.csproj
@@ -22,6 +22,6 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageReference Include="NVorbis" Version="0.10.5" />
-    <PackageReference Include="OpenTK.OpenAL" Version="4.7.7" />
+    <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.8.0" />
   </ItemGroup>
 </Project>

--- a/src/Bearded.Audio/Core/SoundBufferData.cs
+++ b/src/Bearded.Audio/Core/SoundBufferData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 using OpenTK.Audio.OpenAL;
 

--- a/src/Bearded.Audio/Core/Source.cs
+++ b/src/Bearded.Audio/Core/Source.cs
@@ -21,7 +21,8 @@ public sealed class Source : IDisposable
     /// <summary>
     /// The current state of this source.
     /// </summary>
-    public ALSourceState State => AudioContext.Instance.Eval(AL.GetSourceState, (int) this);
+    public ALSourceState State =>
+        (ALSourceState) AudioContext.Instance.Eval(AL.GetSource, (int) this, ALGetSourcei.SourceState);
 
     /// <summary>
     /// The amount of buffers the source has already played.


### PR DESCRIPTION
## ✨ What's this?
This updates the OpenTK.Audio dependency to 4.8. The name of the package has changed (breaking change), so it was necessary to do a manual update.

## 🔍 Why do we want this?
To stay up-to-date with OpenTK 😁 

## 🏗 How is it done?
Manually changed the dependency, then updated the one broken call.

### 💥 Breaking changes
Updating to this Bearded.Audio version will cause problems if you have other libraries with different OpenTK versions, but this is always a problem. No external breaking changes should be present.

### 🔬 Why not another way?
Dependabot will not pick this up.
